### PR TITLE
Handle the remaining record types (original formatting style)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all
 
 OPT=-g
-CFLAGS=-Wall $(OPT)
+CFLAGS=-Wall -Werror $(OPT)
 
 all: hex2bin hexinfo
 

--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ I used this sequence to break a single .hex output from Microchip's XC8 into pie
     cmp foo.bin io_pic.config.bin
 ```
 
-The function readhex() in readhex.c that hex2bin uses is very old code (thus C language) and only handles 4 record types (store bytes, set high address bytes, execution start, and end).  It probably could be improved.
+The function readhex() in readhex.c that hex2bin uses is very old code (thus C language).  It probably could be improved.

--- a/readhex.c
+++ b/readhex.c
@@ -10,14 +10,14 @@ static int get_nybble(unsigned char *s)
     int value;
 
     if (*s >= '0' && *s <= '9') {
-	value = *s - '0';
+        value = *s - '0';
     } else if (*s >= 'a' && *s <= 'f') {
-	value = *s - 'a' + 10;
+        value = *s - 'a' + 10;
     } else if (*s >= 'A' && *s <= 'F') {
-	value = *s - 'A' + 10;
+        value = *s - 'A' + 10;
     } else {
-	printf("Invalid hex character: %c\n", *s);
-	value = 0;
+        printf("Invalid hex character: %c\n", *s);
+        value = 0;
     }
 
     return value;
@@ -26,13 +26,13 @@ static int get_nybble(unsigned char *s)
 static int get_byte(unsigned char *s)
 {
     /* this is right, shut up: */
-    return get_nybble(s)*16 + get_nybble(s + 1);
+    return get_nybble(s) * 16 + get_nybble(s + 1);
 }
 
 static int get_word(unsigned char *s)
 {
     /* yes this too */
-    return get_byte(s)*256 + get_byte(s + 2);
+    return get_byte(s) * 256 + get_byte(s + 2);
 }
 
 int read_hex(FILE *f, memory_func memory, void *memory_arg, int bad_checksum_is_error)
@@ -50,51 +50,51 @@ int read_hex(FILE *f, memory_func memory, void *memory_arg, int bad_checksum_is_
     int skipped_bytes = 0;
 
     while (fgets(line, sizeof(line), f) != NULL) {
-	s = (unsigned char *) line;
+        s = (unsigned char *)line;
         line_number++;
 
         // Must start with colon.
-	if (*s != ':') {
-	    printf("Bad format on line %d: %s\n", line_number, line);
+        if (*s != ':') {
+            printf("Bad format on line %d: %s\n", line_number, line);
             return 0;
-	}
-	s++;
+        }
+        s++;
 
-	checksum = 0;
-	num_bytes = get_byte(s);
-	if (num_bytes == 0) {
+        checksum = 0;
+        num_bytes = get_byte(s);
+        if (num_bytes == 0) {
             // All done.
-	    break;
-	}
-        checksum += (unsigned char) num_bytes;
-	s += 2;
+            break;
+        }
+        checksum += (unsigned char)num_bytes;
+        s += 2;
 
-	address = get_word(s);
-        checksum += (unsigned char) get_byte(s);
-        checksum += (unsigned char) get_byte(s + 2);
-	s += 4;
+        address = get_word(s);
+        checksum += (unsigned char)get_byte(s);
+        checksum += (unsigned char)get_byte(s + 2);
+        s += 4;
 
-	if ((byte = get_byte(s)) != 0) {
+        if ((byte = get_byte(s)) != 0) {
             s += 2;
-            checksum += (unsigned char) byte;
+            checksum += (unsigned char)byte;
 
-            if(byte == RECORD_SET_EXECUTION_START) {
+            if (byte == RECORD_SET_EXECUTION_START) {
                 start_execution = get_word(s) * 65536 + get_word(s + 4);
-                checksum += (unsigned char) get_byte(s);
-                checksum += (unsigned char) get_byte(s + 2);
-                checksum += (unsigned char) get_byte(s + 4);
-                checksum += (unsigned char) get_byte(s + 6);
+                checksum += (unsigned char)get_byte(s);
+                checksum += (unsigned char)get_byte(s + 2);
+                checksum += (unsigned char)get_byte(s + 4);
+                checksum += (unsigned char)get_byte(s + 6);
                 s += 8;
-            } else if(byte == RECORD_EXTENDED_LINEAR_ADDRESS) {
+            } else if (byte == RECORD_EXTENDED_LINEAR_ADDRESS) {
                 base_address = get_word(s) * 65536;
-                checksum += (unsigned char) get_byte(s);
-                checksum += (unsigned char) get_byte(s + 2);
+                checksum += (unsigned char)get_byte(s);
+                checksum += (unsigned char)get_byte(s + 2);
                 s += 4;
             } else {
                 printf("record type other than 0 or 4\n");
                 return 0;
             }
-	} else {
+        } else {
             // byte doesn't affect checksum because it's 0
             s += 2;
 
@@ -102,7 +102,7 @@ int read_hex(FILE *f, memory_func memory, void *memory_arg, int bad_checksum_is_
                 byte = get_byte(s);
                 s += 2;
 
-                checksum += (unsigned char) byte;
+                checksum += (unsigned char)byte;
 
                 memory(memory_arg, base_address + address, byte);
 
@@ -115,8 +115,8 @@ int read_hex(FILE *f, memory_func memory, void *memory_arg, int bad_checksum_is_
         int file_checksum = get_byte(s);
         if (checksum != file_checksum) {
             printf("Checksum mismatch on line %d: %02x vs %02x\n",
-                    line_number, checksum, file_checksum);
-            if(bad_checksum_is_error)
+                   line_number, checksum, file_checksum);
+            if (bad_checksum_is_error)
                 return 0;
         }
     }
@@ -125,7 +125,7 @@ int read_hex(FILE *f, memory_func memory, void *memory_arg, int bad_checksum_is_
         printf("Skipped %d bytes.\n", skipped_bytes);
     }
 
-    if(start_execution >= 0)
+    if (start_execution >= 0)
         printf("start execution at 0x%08X\n", start_execution);
 
     return 1;
@@ -142,7 +142,7 @@ void memory_desc_init(struct memory_desc *mi, unsigned char *p, off_t offset, si
 void memory_desc_store(void *arg, int address, unsigned char c)
 {
     struct memory_desc *mi = (struct memory_desc *)arg;
-    if(address >= mi->offset && address < mi->offset + mi->size) {
+    if (address >= mi->offset && address < mi->offset + mi->size) {
         int offset = address - mi->offset;
         mi->p[offset] = c;
         if (offset + 1 > mi->size_written) {
@@ -150,4 +150,3 @@ void memory_desc_store(void *arg, int address, unsigned char c)
         }
     }
 }
-


### PR DESCRIPTION
Here's a redo of #1.

I wanted formatting consistency, and created a style with the `indent` tool that most closely matches the existing code. It still required some touch-up afterwards, since it doesn't recognize the non-base types when deciding on spacing for casting and pointer parameters, e.g. `(uint8_t *) var` vs `(uint8_t *)var` and `f(uint8_t * p)` vs `f(uint8_t *p)`.

https://www.gnu.org/software/indent/manual/indent.html
`indent -nbad -bap -bbo -nbc -br -brs -ncdb -ce -ci4 -cli0 -ncs -d0 -di1 -nfc1 -nfca -hnl -i4 -ip0 -lp -npcs -nprs -npsl -saf -sai -saw -nsc -nsob -nss -l100 -nut readhex.c`